### PR TITLE
Using link instead of itemID for `item_value`

### DIFF
--- a/addon.lua
+++ b/addon.lua
@@ -274,7 +274,7 @@ function GetConsideredItemInfo(bag, slot)
 		end
 	end
 
-	local value, source, sellable = item_value(itemid, quality < db.profile.auction_threshold)
+	local value, source, sellable = item_value(link, quality < db.profile.auction_threshold)
 	if (not value) or value == 0 then
 		if db.profile.valueless or action then
 			-- forced things should _always_ go through, otherwise it depends on the valueless setting


### PR DESCRIPTION
I've noticed that the merchant prices for gear are often completely wrong (e.g. something like 34c instead of the real 14s12c or so for a gray gear item).

The correct prices can be obtained by using the item link instead of the ID.

However, I'm pretty sure you knew that, so I'm wondering if there's a specific reason why you weren't using the item link…

I'm using the modification for about a week now, and didn't notice any anomalies.