### PR TITLE
Compatibility with TSM and Auctionator prices

### DIFF
--- a/addon.lua
+++ b/addon.lua
@@ -116,8 +116,14 @@ end
 -- returns: price, source, vendorable
 function item_value(item, force_vendor)
 	local vendor = select(11, GetItemInfo(item)) or 0
-	if db.profile.auction and GetAuctionBuyout and not force_vendor then
-		local auction = GetAuctionBuyout(item) or 0
+	if db.profile.auction and (TSM_API or Auctionator) and not force_vendor then
+		local auction
+		if TSM_API then
+			local tsm_item = TSM_API.ToItemString(item)
+			auction = (TSM_API.GetCustomPriceValue("DBRecent", tsm_item)) or (TSM_API.GetCustomPriceValue("DBMarket", tsm_item)) or 0
+		else
+			auction = Auctionator.API.v1.GetAuctionPriceByItemLink('DropTheCheapestThing', item) or 0
+		end
 		if auction > vendor then
 			return auction, 'auction', vendor > 0
 		end


### PR DESCRIPTION
Ir seems the `GetAuctionBuyout` API you are using is unknown to modern TSM and Auctionator.

So this is a very basic implementation to get the prices from TSM or Auctionator (in that priority).

**Important**: The modification in its current form requires that the item link is used for the `item` parameter of the function, as proposed in [PR 17](https://github.com/kemayo/wow-dropthecheapestthing/pull/17)! Otherwise at least the Auctionator function must be changed.

This is only tested with Retail, not Classic or Wrath, as I'm not playing those.